### PR TITLE
Support setting log level with Python parameter, document

### DIFF
--- a/doc/tweaks.md
+++ b/doc/tweaks.md
@@ -1,8 +1,14 @@
 # Tweaking metovlogs
-## `LOG_LEVEL` environment variable
-You can change the level of logs shown by metovlogs by setting an environment variable:
-```
-export LOG_LEVEL=INFO
-```
+## Log level
+The minimum log level shown by metovlogs is the first of:
 
-And the logs will now be at info level. For a full list of levels, see the `coloredlogs` [documentation](https://coloredlogs.readthedocs.io/en/latest/api.html#coloredlogs.find_defined_levels).
+* The `LOG_LEVEL` environment variable
+* The `default_level` parameter
+* The `DEFAULT_LEVEL` constant
+
+For example, if you want to set the level to `INFO`:
+* Environment variable: Run `export LOG_LEVEL=INFO` in your shell
+* Parameter: Create your logger with `log = get_log(__name__, "INFO")`
+* Constant: This should always be `DEBUG`, so that's what you get if you don't set the level
+
+For a full list of levels, see the `coloredlogs` [documentation](https://coloredlogs.readthedocs.io/en/latest/api.html#coloredlogs.find_defined_levels) (under the hood, I use coloredlogs, so metovlogs inherits the same level names).

--- a/metovlogs/__init__.py
+++ b/metovlogs/__init__.py
@@ -4,7 +4,7 @@ import coloredlogs
 from . import lib
 
 
-def get_log(name: str) -> logging.Logger:
+def get_log(name: str, default_level: str = None) -> logging.Logger:
     log = logging.getLogger(name)
     fields = [
         "{name}:{lineno}",
@@ -14,7 +14,7 @@ def get_log(name: str) -> logging.Logger:
     coloredlogs.install(
         fmt=" ".join(fields),
         style="{",
-        level=lib.level_from_envar(),
+        level=default_level or lib.level_from_envar(),
         logger=log,
     )
     return log

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="metovlogs",
-    version="0.1.2",
+    version="0.1.3",
     description="Dead simple Python logging.",
     url="https://github.com/metov/metovlogs",
     long_description=Path("README.md").read_text(),


### PR DESCRIPTION
Adds some more control over log levels.

You can now pass a parameter to `get_log` (gets overridden by the envar). Rationale: Although the idea is to minimize customization and target early stage programs, I am now happily using metovlogs in quite a few of my own projects that are mature enough to need more control over log levels. Yet metovlogs is otherwise adequate. So instead of taking my own advice to "set up proper logging", I'll give in to scope creep 😛. In my defense, as scope creeps go, this one is quite small and innocent 👼.

Setting the constant was already possible, but I decided to document it. Right now, every Python file must do `log = get_log("log_name")`. If you want to use the parameter, you would have to pass the same value every time. It can get tedious if there are many files in your program. On the other hand, the constant can be set once in your main `__init__.py` and it nicely applies to the whole package, and it can still be overwritten by individual files (by passing the parameter to `get_log`) and by the user (by setting the envar).

Mutating the constant does sound weird, but then again it's not `_DEFAULT_LEVEL` so seems fair game. And also no constants in Python anyways 🤷.
